### PR TITLE
mailchimp-subscribe-modal fields to full width

### DIFF
--- a/components/mailchimp/mailchimp-subscribe-modal.tsx
+++ b/components/mailchimp/mailchimp-subscribe-modal.tsx
@@ -70,7 +70,7 @@ export default function MailchimpSubscibeModal() {
           >
             <MailChimpTitle />
             <MailChimpSubtext />
-            <MailChimpFields className="input input-xl input-neutral border border-gray-800" />
+            <MailChimpFields className="input input-xl input-neutral border border-gray-800 w-full" />
             {error && <span className="text-red-500">{error}</span>}
             <MailChimpDisclaimer />
             <div className="flex gap-4 justify-end">


### PR DESCRIPTION
Fixing modal field width:

### Before
![image](https://github.com/user-attachments/assets/f0ce99d6-f5af-425e-baf6-0017cfad5792)

### After
![image](https://github.com/user-attachments/assets/52f1526a-b715-4715-b34d-81c3b1dbcf49)
