### PR TITLE
add a newsletter signup page for direct-linking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const bodyClass = `flex flex-col h-screen ${mulish.className}`;
   return (
     <html lang="en" suppressHydrationWarning={true}>
       <head>
@@ -25,12 +26,12 @@ export default function RootLayout({
         <meta name="viewport" content="initial-scale=1, width=device-width" />
         <link rel="shortcut icon" href="/kcesar/favicon.ico" />
       </head>
-      <body className={mulish.className}>
-        <div>
-          <Navbar />
-          {children}
-          <Footer />
-        </div>
+      <body className={bodyClass}>
+        <Navbar />
+          <div className="flex-1">
+            {children}
+          </div>
+        <Footer />
       </body>
     </html>
   );

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,0 +1,20 @@
+import Banner from "@/components/banner/banner";
+import BasicBody from "@/components/layout/basicbody";
+import BasicLayout from "@/components/layout/basiclayout";
+import MailchimpSubscribeForm from "@/components/mailchimp/mailchimp-subscribe";
+
+export default async function ContactUs() {
+  let pageTitle = "The Dispatch";
+  return (
+    <BasicLayout>
+      <Banner
+        title={pageTitle}
+        location="/kcesar/advanced-litter/advanced-litter-47.jpg"
+        alt="Rescuers walking up a snowy trail"
+      />
+      <BasicBody>
+        <MailchimpSubscribeForm />
+      </BasicBody>
+    </BasicLayout>
+  );
+}

--- a/components/mailchimp/mailchimp-subscribe.tsx
+++ b/components/mailchimp/mailchimp-subscribe.tsx
@@ -40,29 +40,27 @@ export default function MailchimpSubscribeForm() {
   };
 
   return (
-    <>
-      <div className="bg-base-200">
-        <MailChimpTitle />
-        <MailChimpSubtext />
-        <form
-          ref={form}
-          className="flex flex-wrap items-center justify-center gap-4"
-          onSubmit={handleSubmit}
-          onChange={() => setError(null)}
+    <div className="flex flex-col items-center justify-center gap-4 p-4">
+      <MailChimpTitle />
+      <MailChimpSubtext />
+      <form
+        ref={form}
+        className="flex flex-wrap items-center justify-center gap-4 flex-col xl:flex-row"
+        onSubmit={handleSubmit}
+        onChange={() => setError(null)}
+      >
+        <MailChimpFields className="input input-xl input-neutral border border-gray-800 w-64" />
+        <button
+          disabled={isSubmitting}
+          className="btn bg-esar-green text-white w-64 h-14"
+          type="submit"
         >
-          <MailChimpFields className="input input-xl input-neutral border border-gray-800 w-64" />
-          <button
-            disabled={isSubmitting}
-            className="btn bg-esar-green text-white w-64"
-            type="submit"
-          >
-            Submit
-          </button>
-        </form>
-        {error && <span className="text-red-500">{error}</span>}
-        {thankYou && <span>{thankYou}</span>}
-        <MailChimpDisclaimer />
-      </div>
-    </>
+          Submit
+        </button>
+      </form>
+      {error && <span className="text-red-500">{error}</span>}
+      {thankYou && <span>{thankYou}</span>}
+      <MailChimpDisclaimer />
+    </div>
   );
 }


### PR DESCRIPTION
- Added newsletter signup page `/newsletter`
- Updated styling on the `mailchimp-subscribe` component so it's not dependent on styling of the parent component.
- Implemented sticky footer so the footer doesn't float above the bottom of the screen on short pages