### PR TITLE
Freshen join-us content + fix button radius & sticky header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,26 @@
 @import "tailwindcss";
 @plugin "daisyui";
 
+/*
+  daisyUI v5 ties button/field corners to --radius-field, whose default theme
+  value is 0.25rem. daisyUI v4 rounded buttons at 0.5rem (--rounded-btn), so the
+  v4->v5 upgrade visibly flattened every .btn. Restore the original radius.
+  Uses :root:root to outrank daisyUI's own :root theme declaration.
+*/
+:root:root {
+  --radius-field: 0.5rem;
+}
+
+/*
+  Under turbopack (next dev), daisyUI v5's base `.btn` rule is emitted without
+  its corner-radius declaration (only `.prose .btn` gets it), so plain buttons
+  render as sharp rectangles. Reassert the radius for all non-circle/square
+  buttons. Harmless in the production build, where the value matches.
+*/
+.btn:not(.btn-circle):not(.btn-square) {
+  border-radius: var(--radius-field);
+}
+
 @theme {
   --color-esar-green: #026737;
 

--- a/app/join-us/basic-training-overview/page.tsx
+++ b/app/join-us/basic-training-overview/page.tsx
@@ -25,7 +25,7 @@ export default async function BasicTrainingOverview() {
         members for the challenges that they will face in the field. As a
         trainee, you will receive instruction and demonstrate proficiency in
         wilderness navigation, survival skills, search method theory, first aid,
-        and evidence search procedures. Basic Training begins in July and runs through April. 
+        and evidence search procedures. Basic Training begins in August and runs through March.
         It is purposefully scheduled during the winter months to give trainees experience working
         in the challenging conditions they could encounter on a mission.
         Training may involve snow, ice, wind, rain, and other unpleasant

--- a/app/join-us/training-materials/page.tsx
+++ b/app/join-us/training-materials/page.tsx
@@ -61,7 +61,7 @@ export default async function TrainingMaterials() {
         <div className="divider py-10"></div>
         <div id="training-calendar" />
         <div className="pb-10">
-          <Subtitle content="2025-2026 Training Season" />
+          <Subtitle content="2026-27 Training Season" />
         </div>
         <MailchimpSubscribeForm />
         <div className="divider" />

--- a/app/join-us/training-materials/trainingcalendar.tsx
+++ b/app/join-us/training-materials/trainingcalendar.tsx
@@ -40,7 +40,9 @@ export default function TrainingCalendar({
                 <tr key={index}>
                   <td>{session.course.name}</td>
                   <td>
-                    {`${session.session.course_date} ${session.session.course_start_time} - ${session.session.course_end_time}`}
+                    {session.session.course_start_time
+                      ? `${session.session.course_date} ${session.session.course_start_time} - ${session.session.course_end_time}`
+                      : session.session.course_date}
                   </td>
                   <td>
                     {session.course.id === "CRSA" ? (

--- a/app/join-us/training-materials/trainingdates.ts
+++ b/app/join-us/training-materials/trainingdates.ts
@@ -261,234 +261,80 @@ export type Session = {
 const sessions: Session[] = [
     {
       course_id: "CRSA",
-      course_date: "July 17th",
-      course_start_time: "7:00pm",
-      course_end_time: "9:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "CRSA",
-      course_date: "July 21st",
-      course_start_time: "6:30pm",
-      course_end_time: "8:30pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "CRSA",
-      course_date: "July 22nd",
-      course_start_time: "7:00pm",
-      course_end_time: "9:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "CRSA",
-      course_date: "July 28th",
-      course_start_time: "7:00pm",
-      course_end_time: "9:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "MEET",
-      course_date: "August 6th",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "MEET",
-      course_date: "August 8th",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "MEET",
-      course_date: "August 9th",
-      course_start_time: "8:30am",
-      course_end_time: "11:30am",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "MEET",
-      course_date: "August 20th",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "MEET",
-      course_date: "August 28th",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "CRSB",
-      course_date: "September 13th",
-      course_start_time: "9:00am",
-      course_end_time: "5:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "CRSB",
-      course_date: "September 21st",
-      course_start_time: "9:00am",
-      course_end_time: "5:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "CRSB",
-      course_date: "October 5th",
-      course_start_time: "9:00am",
-      course_end_time: "5:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "SFA1",
-      course_date: "October 11th",
-      course_start_time: "9:00am",
-      course_end_time: "6:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "SFA1",
-      course_date: "October 26th",
-      course_start_time: "9:00am",
-      course_end_time: "6:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "SFA1",
-      course_date: "November 8th",
-      course_start_time: "9:00am",
-      course_end_time: "6:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "CRSC",
-      course_date: "November 1-2",
-      course_start_time: "Sat 6:30am",
-      course_end_time: "Sun 4:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRSC",
-      course_date: "November 15-16",
-      course_start_time: "Sat 6:30am",
-      course_end_time: "Sun 4:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRSC",
-      course_date: "December 6-7",
-      course_start_time: "Sat 6:30am",
-      course_end_time: "Sun 4:00pm",
-      location_id: "CAMPED"
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
+      location_id: "TBDTBD"
     },
     {
       course_id: "CRS1",
-      course_date: "December 6-7",
-      course_start_time: "Sat 6:20am",
-      course_end_time: "Sun 3:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRS1",
-      course_date: "January 10-11",
-      course_start_time: "Sat 6:20am",
-      course_end_time: "Sun 3:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRS1",
-      course_date: "January 24-25",
-      course_start_time: "Sat 6:20am",
-      course_end_time: "Sun 3:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "SFA2",
-      course_date: "December 13th",
-      course_start_time: "9:00am",
-      course_end_time: "6:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "SFA2",
-      course_date: "January 17th",
-      course_start_time: "9:00am",
-      course_end_time: "6:00pm",
-      location_id: "TBDTBD"
-    },
-    {
-      course_id: "SFA2",
-      course_date: "January 31st",
-      course_start_time: "9:00am",
-      course_end_time: "6:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "CRS2",
-      course_date: "January 24-25",
-      course_start_time: "Sat 7:00am",
-      course_end_time: "Sun 3:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRS2",
-      course_date: "February 7-8",
-      course_start_time: "Sat 7:00am",
-      course_end_time: "Sun 3:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRS2",
-      course_date: "February 21-22",
-      course_start_time: "Sat 7:00am",
-      course_end_time: "Sun 3:00pm",
-      location_id: "CAMPED"
-    },
-    {
-      course_id: "CRS3",
-      course_date: "March 7-8",
-      course_start_time: "Sat 7:00am",
-      course_end_time: "Sun 3:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "CRS3",
-      course_date: "March 21-22",
-      course_start_time: "Sat 7:00am",
-      course_end_time: "Sun 3:00pm",
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
       location_id: "TBDTBD"
     },
     {
       course_id: "OPS1",
-      course_date: "March TBD",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
-      location_id: "KCSARA"
-    },
-    {
-      course_id: "OPS1",
-      course_date: "March TBD",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
-      location_id: "KCSARA"
-    },
-    {
-      course_id: "OPS1",
-      course_date: "April TBD",
-      course_start_time: "6:30pm",
-      course_end_time: "9:30pm",
-      location_id: "KCSARA"
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
+      location_id: "TBDTBD"
     },
     {
       course_id: "GRAD",
-      course_date: "April 12th",
-      course_start_time: "2:30pm",
-      course_end_time: "5:00pm",
-      location_id: "SIVIEW"
+      course_date: "TBD",
+      course_start_time: "",
+      course_end_time: "",
+      location_id: "TBDTBD"
     }
   ]
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const bodyClass = `flex flex-col h-screen ${mulish.className}`;
+  const bodyClass = `flex flex-col min-h-screen ${mulish.className}`;
   return (
     <html lang="en" suppressHydrationWarning={true}>
       <head>

--- a/components/join-us/application.tsx
+++ b/components/join-us/application.tsx
@@ -39,8 +39,7 @@ export default function Application({
         <Subtitle content="Thank you for your interest in joining KCESAR." />
         <div className="pt-6">
           <SubSubtitle
-            content="Training for 2025-26 is now underway.
-"
+            content="Joining ESAR is a 7-month process generally beginning in August and ending in March.  Information about applications and scheduling for the 2026-27 training season will be released in July."
           />
         </div>
         <div className="pt-2">


### PR DESCRIPTION
Bundles one content refresh requested by Jeremy plus two reported UI bug fixes.

## 1. Join-us content refresh (per Jeremy's email)
- **/join-us**: replaced "Training for 2025-26 is now underway." with the 7-month-process summary and the note that 2026-27 application/scheduling info releases in July.
- **/join-us/basic-training-overview**: "begins in July and runs through April" → "begins in August and runs through March".
- **/join-us/training-materials**: heading "2025-2026 Training Season" → "2026-27 Training Season"; calendar reset so every course's dates/times and locations show **TBD** until the schedule is finalized (collapsed to one row per course rather than many identical TBD rows). The date cell now renders cleanly when times are blank.

> Note: Course A's location still shows the existing "n/a" display rule, and the hidden "accepting applications" copy + course-prerequisite text still reference 2025-26 — left for the larger July rollout. Easy to fold in if wanted.

## 2. Fix: button corner radius (reported)
The daisyUI v4→v5 upgrade lowered the default `--radius-field` (0.5rem → 0.25rem) and, under turbopack dev, drops the radius declaration from the base `.btn` rule entirely — so buttons like **Basic Training Overview**, **Donate**, and **Newsletter signup** rendered as sharp rectangles. Restores `--radius-field: 0.5rem` and reasserts the radius on non-circle/square buttons. Verified via DevTools computed styles (all → 8px; circle buttons unaffected).

## 3. Fix: sticky header disappears past initial viewport (reported by Valon)
The `<body>` used `h-screen` (`height: 100vh`), so the sticky navbar's containing block was only one viewport tall; scrolling past the initial bottom of the page un-stuck the header. Switched to `min-h-screen`. Verified the header stays pinned at all scroll depths and the footer still anchors on short pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)