### PR TITLE
fix(ci): let production deploy succeed when Bun is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "bun test tests/unit",
+    "test": "if command -v bun >/dev/null 2>&1; then bun test tests/unit; else echo 'bun not found; skipping unit tests (they run in PR checks)'; fi",
     "test:e2e": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem
The **Build/Deploy to Production** workflow (Azure, `deploy-prod.yml`) has failed on **every merge to `main`** since Bun-based unit tests were introduced — including [the merge of #35](https://github.com/kcesar/public_website/actions/runs/29276784761). The build compiles fine, then dies here:

```
> kcesar-2024-website@0.1.0 test
> bun test tests/unit
sh: 1: bun: not found
##[error]Process completed with exit code 127.
```

`deploy-prod.yml` runs on Node 20 + npm (no Bun) and calls `npm run test --if-present`, which invokes the package.json `test` script (`bun test tests/unit`). Bun isn't installed there, so the step exits 127 and the `build` job fails **before** the zip/deploy steps — meaning **production hasn't actually been deploying**.

## Constraint
Per [CLAUDE.md](../blob/main/CLAUDE.md), `deploy-prod.yml` is managed outside this repo's normal workflow and must stay npm/Node-only — it must not be edited or migrated to Bun. So the fix is applied to the `test` script instead.

## Fix
Guard the `test` script on Bun's presence:

```jsonc
"test": "if command -v bun >/dev/null 2>&1; then bun test tests/unit; else echo 'bun not found; skipping unit tests (they run in PR checks)'; fi"
```

- **PR Checks** (`bun run test`, Bun installed): runs the real suite; a failing test still propagates a non-zero exit (verified), so tests remain the merge gate.
- **Azure deploy** (`npm run test`, no Bun): prints a skip message and exits 0, so the build job proceeds to deploy.

`deploy-prod.yml` is untouched.

## Verification (local)
- `bun run test` → 2 pass.
- `env PATH=/usr/bin:/bin sh -c '<script>'` (Bun absent) → prints skip message, **exit 0**.
- Failure propagation under Bun confirmed: `if command -v bun …; then false; fi` → **exit 1**.

After this merges, the production deploy should run its unit-test step as a clean skip and continue to the Azure deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)