### PR TITLE
Rebrand member-units to KCSAR (seven) + emphasize About history button

### DIFF
--- a/app/about/history/page.tsx
+++ b/app/about/history/page.tsx
@@ -28,7 +28,7 @@ export default function History() {
         <CenteredText
           content="King County Explorer Search & Rescue (ESAR) was founded in 1954 
         as one of the first organized search and rescue teams in the country.  Today, it is 
-        the largest of nine member-units of the King County Search & Rescue Association (KCSARA) 
+        the largest of seven member-units of King County Search & Rescue (KCSAR)
         with over 250 active members. "
         />
         <BasicImage

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -105,9 +105,13 @@ export default async function About() {
           alt="The full team hiking out together along a forest trail with a litter"
         />
 
-        <BasicLink title="Our History" href="/about/history" />
-
-        <br />
+        <div className="flex justify-center pt-10 pb-6">
+          <BasicLink
+            title="Read Our History →"
+            href="/about/history"
+            className="btn-lg shadow-lg"
+          />
+        </div>
         <div className="flex flex-wrap justify-center gap-10 p-10">
           {people.map((person) => (
             <Card

--- a/app/join-us/training-materials/trainingdates.ts
+++ b/app/join-us/training-materials/trainingdates.ts
@@ -100,7 +100,7 @@ export type CourseLocation = {
 const locations: CourseLocation[] = [
     {
       id: "KCSARA",
-      name: "KCSARA HQ",
+      name: "KCSAR HQ",
       street_address: "34501 SE 99th St, Snoqualmie",
       google_maps_url: "https://goo.gl/maps/GrLHi5q6giKDrTcc7"
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
 
               <GridText
                 title="Who We Are"
-                body="King County Explorer Search & Rescue (also known as KCESAR or ESAR) is the primary ground search and rescue resource in King County and the largest of nine member-units in the King County Search & Rescue Association. We operate under the purview of the King County Sheriff's Office and Washington State Department of Emergency Management."
+                body="King County Explorer Search & Rescue (also known as KCESAR or ESAR) is the primary ground search and rescue resource in King County and the largest of seven member-units in King County Search & Rescue (KCSAR). We operate under the purview of the King County Sheriff's Office and Washington State Department of Emergency Management."
                 link="/about"
                 linkText="Learn More"
               />
@@ -64,7 +64,7 @@ export default function Home() {
               />
               <GridText
                 title="Who We Are"
-                body="ESAR is the primary ground search and rescue resource in King County and the largest of nine member-units in the King County Search & Rescue Association. We operate under the purview of the King County Sheriff's Office and Washington State Department of Emergency Management."
+                body="ESAR is the primary ground search and rescue resource in King County and the largest of seven member-units in King County Search & Rescue (KCSAR). We operate under the purview of the King County Sheriff's Office and Washington State Department of Emergency Management."
                 link="/about"
                 linkText="Learn More"
               />

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
         <p className="text-sm md:text-lg pb-10 drop-shadow-xl md:[text-shadow:0_1px_4px_rgb(0_0_0/60%)]">
           King County Explorer Search & Rescue is one of the earliest Search &
           Rescue organizations established in the United States and the largest
-          of nine member-units of the King County Search & Rescue Association.
+          of seven member-units of King County Search & Rescue (KCSAR).
         </p>
         <div className="flex flex-col gap-2 justify-center items-center">
           <BasicLink title="Join Us" href="/join-us" />

--- a/components/navigation/basiclink.tsx
+++ b/components/navigation/basiclink.tsx
@@ -3,14 +3,16 @@ import Link from "next/link";
 export default function BasicLink({
   title,
   href,
+  className = "",
 }: {
   title: string;
   href: string;
+  className?: string;
 }) {
   return (
     <Link
       href={href}
-      className="btn bg-esar-green hover:bg-base-300 text-white border-none"
+      className={`btn bg-esar-green hover:bg-base-300 text-white border-none ${className}`}
     >
       {title}
     </Link>


### PR DESCRIPTION
Two content changes.

## 1. Rebrand: "seven member-units of King County Search & Rescue (KCSAR)"
Several pages still said *"nine member-units"* of the *"King County Search & Rescue Association (KCSARA)"*. Updated the count to **seven** and the name/acronym to **King County Search & Rescue (KCSAR)** everywhere it appears, matching the About page:

- [app/page.tsx](../blob/main/app/page.tsx) — both the mobile and desktop intro cards
- [components/home/hero.tsx](../blob/main/components/home/hero.tsx) — hero subtitle
- [app/about/history/page.tsx](../blob/main/app/about/history/page.tsx) — "The Early Years"
- [trainingdates.ts](../blob/main/app/join-us/training-materials/trainingdates.ts) — renamed the **"KCSARA HQ"** training venue to **"KCSAR HQ"** (left the internal `id` key untouched — it isn't rendered)

Verified on the running home page: 2× "seven member-units", 2× "King County Search & Rescue (KCSAR)", zero remaining "nine"/"Association" strings.

## 2. About: emphasize the "Read Our History" button
Reported issue: the history button sat flush against the "Who We Are" image and was easy to miss.
- Wrapped it in a centered container with padding (now a **40px** gap above, was ~0).
- Made the CTA larger (`btn-lg`) with an arrow, relabeled "Read Our History →".
- `BasicLink` gains an optional `className` passthrough (default empty), so its other uses are unchanged.

Verified via computed styles (48px tall, 18px text, 40px separation).

> Note: the button's new label/size/`shadow-lg` is a judgment call — happy to dial it back to the plain "Our History" label or a smaller size if you'd prefer. (daisyUI's `.btn` overrides `shadow-lg`, so the shadow currently has no visible effect; I can force it with `shadow-lg!` if you want the drop shadow.)

Lint clean, production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)