### PR TITLE
fix: route Members tab through Google account chooser

### DIFF
--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -33,7 +33,7 @@ export default function Navbar() {
     { href: "/join-us", label: "Join Us" },
     { href: "/contact-us", label: "Contact Us" },
     {
-      href: "https://sites.google.com/kcesar.org/members",
+      href: "https://accounts.google.com/AccountChooser?continue=https%3A%2F%2Fsites.google.com%2Fkcesar.org%2Fmembers",
       label: "Members",
       external: true,
     },


### PR DESCRIPTION
## Problem

Clicking the **Members** tab while signed out of KCESAR (or signed into the wrong Chrome profile) returns Google's 404 "broken robot" page instead of a login screen. This is intentional Google Sites behavior — restricted pages return 404 to unauthorized visitors rather than revealing that the page exists — and there is no Google Sites setting to change it. It's especially confusing for members who maintain multiple Chrome profiles (Work / Personal / SAR).

## Fix

Route the Members link through Google's account chooser instead of hitting the restricted site directly:

```
https://accounts.google.com/AccountChooser?continue=https%3A%2F%2Fsites.google.com%2Fkcesar.org%2Fmembers
```

Now clicking **Members** surfaces Google's "choose an account / sign in" screen first, then forwards to the members site once an account is selected.

## Behavior

- **Signed out / wrong profile** → account picker appears; pick the SAR account and get forwarded to the members site.
- **Already signed in with an authorized account** → passes straight through as before.
- **Authorized-but-not-a-member account** → still lands on the 404, since that's Google enforcing the site's own access list (unchanged, and out of our control).

Single-line change in `components/navbar/navbar.tsx`, which drives both the desktop nav and the mobile drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)